### PR TITLE
[#224] feat(마이페이지) : 내 글 페이지 반응형 작업

### DIFF
--- a/src/app/(protect)/my-page/board/page.tsx
+++ b/src/app/(protect)/my-page/board/page.tsx
@@ -5,25 +5,18 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getMe } from "@/lib/api/auth/auth.server";
 import { getMyWrittenPosts, getMyWrittenComments } from "@/lib/api/myPage/myPage.server";
 import { User } from "@/types/user";
-import { twMerge } from "tailwind-merge";
 
 export default async function Page() {
   const posts = await getMyWrittenPosts();
   const comments = await getMyWrittenComments();
-  // const likes = await getMyLikePosts();
 
   const res = await getMe();
   const userData = res.data as User;
 
   return (
-    <div className="my-15 px-15">
+    <div className="space-y-20 px-5 py-8 lg:px-15 lg:py-10">
       <Tabs defaultValue="posts" className="gap-10">
-        <TabsList
-          className={twMerge(
-            "bg-background w-full justify-center gap-10",
-            "*:flex-none *:border-none *:p-0 *:text-xl *:shadow-none!"
-          )}
-        >
+        <TabsList className="bg-background *:text-text-sub *:aria-selected:text-text-main w-full justify-center gap-10 *:flex-none *:border-none *:p-0 *:text-base *:font-bold *:shadow-none! md:*:text-lg lg:*:text-xl">
           <TabsTrigger value="posts" className="bg-background!">
             내가 작성한 글
           </TabsTrigger>
@@ -31,10 +24,6 @@ export default async function Page() {
           <TabsTrigger value="comments" className="bg-background!">
             내가 작성한 댓글
           </TabsTrigger>
-          {/* <Separator orientation="vertical" className="bg-border! h-4!" />
-          <TabsTrigger value="likes" className="bg-background!">
-            좋아요한 글
-          </TabsTrigger> */}
         </TabsList>
         <section className="mx-auto w-full max-w-400">
           <TabsContent value="posts">
@@ -43,9 +32,6 @@ export default async function Page() {
           <TabsContent value="comments">
             <MyPageCommentList user={userData} comments={comments.data?.content} />
           </TabsContent>
-          {/* <TabsContent value="likes">
-            <MyPageLikeList likes={likes.data?.content} />
-          </TabsContent> */}
         </section>
       </Tabs>
     </div>

--- a/src/components/my-page/MyPageCommentList.tsx
+++ b/src/components/my-page/MyPageCommentList.tsx
@@ -5,6 +5,8 @@ import { CommentItemPage } from "@/types/my-page";
 import { User } from "@/types/user";
 import { formatDistanceToNow } from "date-fns";
 import { ko } from "date-fns/locale";
+import { MessageCircleIcon } from "lucide-react";
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "../ui/empty";
 
 export default function MyPageCommentList({
   user,
@@ -15,30 +17,54 @@ export default function MyPageCommentList({
 }) {
   return (
     <div className="flex flex-col gap-4">
+      {comments?.length === 0 && (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <MessageCircleIcon />
+            </EmptyMedia>
+            <EmptyTitle>작성한 댓글이 없습니다.</EmptyTitle>
+            <EmptyDescription>커뮤니티에서 활동을 시작해보세요!</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
       {comments?.map((comment) => (
         <Link
           key={comment.commentId}
+          // TODO: 댓글 API 응답값 업데이트 되면 href 수정 필요
           href="#"
-          className="border-border flex cursor-pointer justify-between gap-4 rounded-xl border p-6"
+          className="border-border hover:bg-accent/50 group flex flex-col gap-4 rounded-2xl border p-6"
         >
-          <div className="flex justify-between">
-            <Avatar className="size-10">
+          <div className="flex justify-between gap-4">
+            <Avatar className="ring-border size-10 ring-4">
               <AvatarImage src={user.profileImageUrl} alt={user.nickname} />
               <AvatarFallback>
                 <ProfileNoImage size="sm" />
               </AvatarFallback>
             </Avatar>
-          </div>
-          <div className="flex-1 space-y-4">
-            <div className="space-y-1">
-              <strong className="text-text-main text-base font-semibold">{user.nickname}</strong>
-              <p className="text-text-sub text-xs">
-                {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true, locale: ko })}
+            <div className="flex-1">
+              <div className="flex justify-between gap-1">
+                <strong className="text-text-main text-sm font-semibold">{user.nickname}</strong>
+                {/* TODO: 댓글 API 응답값 업데이트 되면 진행 */}
+                {/* <Badge variant="outline" className="px-2 py-1">
+                  {comment.category === "REVIEW" ? "공연 후기" : "동행 구인"}
+                </Badge> */}
+              </div>
+              <p className="text-text-sub text-xs leading-normal lg:text-sm">
+                {formatDistanceToNow(new Date(comment.createdAt), {
+                  addSuffix: true,
+                  locale: ko,
+                })}
               </p>
             </div>
-            <div className="space-y-2">
-              <p className="text-text-sub line-clamp-3">{comment.content}</p>
-            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <h4 className="text-text-main text-base font-semibold lg:text-lg">
+              {comment.postTitle}
+            </h4>
+            <p className="text-text-sub line-clamp-4 text-sm break-keep lg:text-base">
+              {comment.content}
+            </p>
           </div>
         </Link>
       ))}

--- a/src/components/my-page/MyPagePostList.tsx
+++ b/src/components/my-page/MyPagePostList.tsx
@@ -6,43 +6,60 @@ import { User } from "@/types/user";
 import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
 import { ko } from "date-fns/locale";
 import { Badge } from "../ui/badge";
+import { StickyNoteIcon } from "lucide-react";
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "../ui/empty";
 
 export default function MyPagePostList({ user, posts }: { user: User; posts?: PostItemPage[] }) {
   return (
     <div className="flex flex-col gap-4">
+      {posts?.length === 0 && (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <StickyNoteIcon />
+            </EmptyMedia>
+            <EmptyTitle>작성한 게시물이 없습니다.</EmptyTitle>
+            <EmptyDescription>커뮤니티에서 활동을 시작해보세요!</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
       {posts?.map((post) => (
         <Link
           key={post.postId}
-          href="#"
-          className="border-border flex cursor-pointer justify-between gap-4 rounded-xl border p-6"
+          href={
+            post.category === "REVIEW"
+              ? `/concerts/${post.concertId}`
+              : `/concert-mate/${post.postId}`
+          }
+          className="border-border hover:bg-accent/50 group flex flex-col gap-4 rounded-2xl border p-6"
         >
-          <div className="flex justify-between">
-            <Avatar className="size-10">
-              <AvatarImage src={user.profileImageUrl} alt="아티스트" />
+          <div className="flex justify-between gap-4">
+            <Avatar className="ring-border size-10 ring-4">
+              <AvatarImage src={user.profileImageUrl} alt={user.nickname} />
               <AvatarFallback>
                 <ProfileNoImage size="sm" />
               </AvatarFallback>
             </Avatar>
-          </div>
-          <div className="flex-1 space-y-4">
-            <div className="space-y-1">
+            <div className="flex-1">
               <div className="flex justify-between gap-1">
-                <strong className="text-text-main text-base font-semibold">{user.nickname}</strong>
+                <strong className="text-text-main text-sm font-semibold">{user.nickname}</strong>
                 <Badge variant="outline" className="px-2 py-1">
                   {post.category === "REVIEW" ? "공연 후기" : "동행 구인"}
                 </Badge>
               </div>
-              <p className="text-text-sub text-xs">
+              <p className="text-text-sub text-xs leading-normal lg:text-sm">
                 {formatDistanceToNow(new Date(post.createdAt), {
                   addSuffix: true,
                   locale: ko,
                 })}
               </p>
             </div>
-            <div className="space-y-2">
-              <h4 className="text-text-main text-lg font-bold">{post.title}</h4>
-              <p className="text-text-sub line-clamp-3">{post.content}</p>
-            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <h4 className="text-text-main text-base font-semibold lg:text-lg">{post.title}</h4>
+            <p className="text-text-sub line-clamp-4 text-sm break-keep lg:text-base">
+              {post.content}
+            </p>
           </div>
         </Link>
       ))}


### PR DESCRIPTION
<!-- 제목 양식 -->
<!-- [#이슈번호] type(페이지) : message -->
<!-- 이슈 없을 시 type(페이지) : message -->

## 📖 개요

- 마이페이지 "내 글" 탭의 댓글 및 게시물 목록 반응형 작업
- 빈 상태(Empty) UI 추가

## ✅ 관련 이슈

- Close #224

## 🛠️ 상세 작업 내용

- [x] 내가 작성한 댓글 목록 반응형 레이아웃 작업
- [x] 내가 작성한 게시물 목록 반응형 레이아웃 작업
- [x] 댓글/게시물 빈 상태(Empty) UI 추가

## ⚠️ 주의 사항 (옵션)

<!-- 다른 작업물에 영향을 줄 수 있는 변화가 있다면 적어주세요 -->

## 📸 스크린샷 (옵션)

<!-- UI/UX 변경 사항이 있다면 사진 첨부해주세요 -->
<img width="475" height="939" alt="image" src="https://github.com/user-attachments/assets/e7f691b9-5424-4368-8116-11af211ad952" />
<img width="478" height="942" alt="image" src="https://github.com/user-attachments/assets/cae7df47-abb0-4549-b63e-a9f359fd45f1" />

## 👥 리뷰 확인 사항 (옵션)
<!-- 코드 리뷰 시에 특별히 확인해야 하는 사항이 있으면 적어주세요 -->
<!-- 예시: 제가 지정한 타입 정의가 적절한지 확인 부탁드립니다 -->